### PR TITLE
Fixed donations profile info box bug.

### DIFF
--- a/classes/donationsview.class.php
+++ b/classes/donationsview.class.php
@@ -98,7 +98,7 @@ class DonationsView {
 
 	public static function render_profile_rewards($EnabledRewards, $ProfileRewards) {
 		for ($i = 1; $i <= 4; $i++) {
-			if (isset($EnabledRewards['HasProfileInfo' . $i]) && $ProfileRewards['ProfileInfo' . $i]) {
+			if ($EnabledRewards['HasProfileInfo' . $i] && $ProfileRewards['ProfileInfo' . $i]) {
 ?>
 			<div class="box">
 				<div class="head" style="height: 13px;">


### PR DESCRIPTION
isset() was called instead of checking the boolean value of $EnabledRewards['HasProfileInfo' . $i]

See forum topic: https://what.cd/forums.php?action=viewthread&threadid=187411
