### PR TITLE
Remove What-Network (broken link)

### DIFF
--- a/design/publicfooter.php
+++ b/design/publicfooter.php
@@ -2,7 +2,7 @@
 	</tr>
 </table>
 <div id="foot">
-	<span><a href="#"><?=SITE_NAME?></a> | <a href="http://what-network.net">What-Network</a> | <a href="https://what.cd/gazelle/">Project Gazelle</a></span>
+	<span><a href="#"><?=SITE_NAME?></a> | <a href="https://what.cd/gazelle/">Project Gazelle</a></span>
 </div>
 </body>
 </html>


### PR DESCRIPTION
Remove What-Network (broken link) from public footer. Reported in thread 190141
