### PR TITLE
Fix functionality-affecting typo in recommend_alter.php

### DIFF
--- a/sections/tools/managers/recommend_alter.php
+++ b/sections/tools/managers/recommend_alter.php
@@ -6,7 +6,7 @@ if (!check_perms('site_recommend_own') && !check_perms('site_manage_recommendati
 	error(403);
 }
 
-$GroupIDi = $_GET['groupid'];
+$GroupID = $_GET['groupid'];
 if (!$GroupID || !is_number($GroupID)) {
 	error(404);
 }


### PR DESCRIPTION
Line 9 was $GroupIDi instead of $GroupID. The next few lines run an is_number check on $GroupID, which doesn't exist if the variable is called $GroupID. This makes me wonder how nobody noticed it until now, as the page shouldn't even work.