### PR TITLE
Fixed paranoia inconsistency with users_mod

### DIFF
--- a/classes/paranoia.class.php
+++ b/classes/paranoia.class.php
@@ -80,7 +80,7 @@ function check_paranoia($Property, $Paranoia, $UserClass, $UserID = false) {
 			case 'ratio':
 			case 'uploaded':
 			case 'lastseen':
-				if (check_perms('users_mod', $UserClass))
+				if (check_perms('users_mod'))
 					return PARANOIA_OVERRIDDEN;
 				break;
 			case 'snatched': case 'snatched+':

--- a/classes/permissions.class.php
+++ b/classes/permissions.class.php
@@ -14,8 +14,7 @@ class Permissions {
 		return (
 			isset(G::$LoggedUser['Permissions'][$PermissionName])
 			&& G::$LoggedUser['Permissions'][$PermissionName]
-			&& (G::$LoggedUser['Class'] >= $MinClass
-				|| G::$LoggedUser['EffectiveClass'] >= $MinClass
+			&& (G::$LoggedUser['EffectiveClass'] >= $MinClass
 				|| $Override)
 			) ? true : false;
 	}

--- a/sections/friends/friends.php
+++ b/sections/friends/friends.php
@@ -30,13 +30,14 @@ $DB->query("
 		m.Username,
 		m.Uploaded,
 		m.Downloaded,
-		m.PermissionID,
+		p.Level,
 		m.Paranoia,
 		m.LastAccess,
 		i.Avatar
 	FROM friends AS f
 		JOIN users_main AS m ON f.FriendID = m.ID
 		JOIN users_info AS i ON f.FriendID = i.UserID
+		LEFT JOIN permissions AS p ON p.ID = m.PermissionID
 	WHERE f.UserID = '$UserID'
 	ORDER BY Username
 	LIMIT $Limit");


### PR DESCRIPTION
This pull request:
1) Allows users with users_mod to always view the last seen of other users
2) Fixes an inconsistency with the calls to check_paranoia in sections/friends/friends.php
3) Removed an unnecessary check in check_perms