### PR TITLE
Adding action=user_torrents

### DIFF
--- a/sections/ajax/index.php
+++ b/sections/ajax/index.php
@@ -160,6 +160,9 @@ switch ($_GET['action']) {
 	case 'pushbullet_devices':
 		require(SERVER_ROOT . '/sections/ajax/pushbullet_devices.php');
 		break;
+	case 'user_torrents':
+		require(SERVER_ROOT . '/sections/ajax/user_torrents.php');
+		break;
 	default:
 		// If they're screwing around with the query string
 		json_die("failure");

--- a/sections/ajax/user_torrents.php
+++ b/sections/ajax/user_torrents.php
@@ -1,0 +1,110 @@
+<?
+$UserID = (int)$_GET['userid'];
+$Type = (string)$_GET['type'];
+$Limit = (int)$_GET['limit'];
+$Offset = (int)$_GET['offset'];
+
+if (empty($UserID) || empty($Type)) {
+	json_die("failure", "bad parameters");
+}
+
+if ($UserID != $LoggedUser['ID']) {
+	// We can always view our own torrents
+	$DB->query("
+		SELECT m.Paranoia
+		FROM users_main AS m
+		WHERE m.ID = $UserID");
+
+	if (!$DB->has_results()) { // If user doesn't exist
+		json_die("failure", "no such user");
+	}
+
+	list($Paranoia) = $DB->next_record(MYSQLI_NUM, false);
+
+	$Paranoia = unserialize($Paranoia);
+	if (!is_array($Paranoia)) {
+		$Paranoia = array();
+	}
+}
+
+if (empty($Limit)) {
+	// retrive all values. Somehow this is the accepted way to do this: http://stackoverflow.com/questions/2294842/mysql-retrieve-all-rows-with-limit
+	$Limit = 2147483647;
+}
+if (empty($Offset)) {
+	$Offset = 0;
+}
+
+switch ($Type) {
+	case 'snatched':
+		$From = "FROM xbt_snatched AS s
+					INNER JOIN torrents AS t ON t.ID = s.fid
+					INNER JOIN torrents_group AS g ON t.GroupID = g.ID";
+		$Where = "WHERE s.uid = '$UserID'
+					AND g.CategoryID = '1'";
+		$Order = "ORDER BY s.tstamp DESC";
+		break;
+	case 'seeding':
+		$From = "FROM xbt_files_users AS xfu
+					JOIN torrents AS t ON t.ID = xfu.fid
+					INNER JOIN torrents_group AS g ON t.GroupID = g.ID";
+		$Where = "WHERE xfu.uid = '$UserID'
+					AND xfu.active = 1
+					AND xfu.Remaining = 0";
+		$Order = "ORDER BY xfu.mtime DESC";
+		break;
+	case 'leeching':
+		$From = "FROM xbt_files_users AS xfu
+					JOIN torrents AS t ON t.ID = xfu.fid
+					INNER JOIN torrents_group AS g ON t.GroupID = g.ID";
+		$Where = "WHERE xfu.uid = '$UserID'
+					AND xfu.active = 1
+					AND xfu.Remaining > 0";
+		$Order = "ORDER BY xfu.mtime DESC";
+		break;
+	case 'uploaded':
+		$Type = 'uploads';	// paranoia settings use 'uploads' but the main site typically uses 'uploaded'
+		// fall through
+	case 'uploads':
+		$From = "FROM torrents_group AS g
+					INNER JOIN torrents AS t ON t.GroupID = g.ID";
+		$Where = "WHERE t.UserID = '$UserID'
+					AND g.CategoryID = '1'";
+		$Order = "ORDER BY t.Time DESC";
+		break;
+	default:
+		json_die("failure", $Type." is not a valid type");
+}
+
+$Results = array();
+if (check_paranoia_here($Type)) {
+	$DB->query("SELECT
+					g.ID AS groupId,
+					g.Name AS name,
+					t.ID AS torrentId ".
+				$From." ".$Where." ".$Order." ".
+				"LIMIT $Offset, $Limit");
+	$TorrentGroups = $DB->to_array(false, MYSQLI_ASSOC);
+
+	$Artists = Artists::get_artists($DB->collect('groupId'));
+
+	foreach ($TorrentGroups as $Key => $SnatchInfo) {
+		$TorrentGroups[$Key]['artistName'] = Artists::display_artists($Artists[$SnatchInfo['groupId']], false, false, true);
+		if (Count($Artists[$SnatchInfo['groupId']][1]) === 1)
+			$TorrentGroups[$Key]['artistId'] = $Artists[$SnatchInfo['groupId']][1][0]['id'];
+	}
+	$Results[$Type] = $TorrentGroups;
+} else {
+	$Results[$Type] = "hidden";
+}
+
+json_print("success", $Results);
+
+function check_paranoia_here($Setting) {
+	global $Paranoia, $Class, $UserID, $Preview;
+	if ($Preview == 1) {
+		return check_paranoia($Setting, $Paranoia, $Class);
+	} else {
+		return check_paranoia($Setting, $Paranoia, $Class, $UserID);
+	}
+}


### PR DESCRIPTION
Adding new AJAX end point: `user_torrents`. This allows the retrieval of the torrents and primary artists for the torrents a user is seeding from one of the four types: seeding, leeching, uploaded, snatched. The end point properly handles paranoia settings for non-logged in users.

Required variables:
`userid`: the user to retrieve torrent information for
`type`: seeding, leeching, uploaded, snatched

Optional
`limit`, `offset`

An example request and response:

// https://what.cd/ajax.php?action=user_torrents&userid=2&type=seeding&limit=3&offset=1

```
{
  "status": "success",
  "response": {
    "seeding": [
      {
        "groupId": "4",
        "name": "If You Have Ghost",
        "torrentId": "4",
        "artistName": "Ghost B.C.",
        "artistId": "4"
      },
      {
        "groupId": "3",
        "name": "Absolute Dissent",
        "torrentId": "3",
        "artistName": "Killing Joke",
        "artistId": "3"
      }
    ]
  }
}
```